### PR TITLE
Fix bug in iterative alignments not evaluating full set of traces

### DIFF
--- a/client/src/fastapi_client/index.ts
+++ b/client/src/fastapi_client/index.ts
@@ -21,6 +21,7 @@ export type { JudgeCreateRequest } from './models/JudgeCreateRequest';
 export type { JudgeResponse } from './models/JudgeResponse';
 export type { JudgeTraceResult } from './models/JudgeTraceResult';
 export type { LabelingProgress } from './models/LabelingProgress';
+export type { SchemaInfo } from './models/SchemaInfo';
 export type { TestJudgeRequest } from './models/TestJudgeRequest';
 export type { TestJudgeResponse } from './models/TestJudgeResponse';
 export type { TraceRequest } from './models/TraceRequest';

--- a/client/src/fastapi_client/models/JudgeResponse.ts
+++ b/client/src/fastapi_client/models/JudgeResponse.ts
@@ -2,6 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { SchemaInfo } from './SchemaInfo';
 /**
  * Response model for judge information.
  */
@@ -30,5 +31,9 @@ export type JudgeResponse = {
      * MLflow run ID for labeling session
      */
     labeling_run_id?: (string | null);
+    /**
+     * Cached schema analysis for consistent use
+     */
+    schema_info?: (SchemaInfo | null);
 };
 

--- a/server/services/cache_service.py
+++ b/server/services/cache_service.py
@@ -147,7 +147,7 @@ class CacheService:
                 return None
 
             sanitized_name = sanitize_judge_name(judge.name)
-            run_name_pattern = f'evaluation_{sanitized_name}_v{judge_version}'
+            run_name_pattern = f'evaluation_{sanitized_name}_v{judge_version}_{dataset_version}'
 
             # Search for runs by name pattern
             all_runs = mlflow.search_runs(
@@ -157,7 +157,7 @@ class CacheService:
             )
 
             for run in all_runs:
-                if run.info.run_name and run_name_pattern in run.info.run_name:
+                if run.info.run_name and run.info.run_name == run_name_pattern:
                     run_id = run.info.run_id
                     # Cache the found run
                     self.evaluation_cache[f'{judge_id}:{judge_version}:{dataset_version}'] = run_id


### PR DESCRIPTION
Currently, we do this flow for alignment:

  1. Run evaluation on the existing set of traces with judge version v_i
  2. Run alignment to go from judge v_i to v_i+1
  3. Run evaluation on the exiting set of traces with judge version v_i+1

If there is an existing evaluation run, we will use that. However, we are incorrectly using the evaluation from step #3 in the next alignment run due to a caching bug.